### PR TITLE
feat: add Uptime Kuma push monitor support to backup modules

### DIFF
--- a/tf/db_backup/main.tf
+++ b/tf/db_backup/main.tf
@@ -3,15 +3,14 @@ locals {
   mariadb_image = "mariadb:10.11"
 
   commands = { for k, v in var.backups : k =>
-    v.db_type == "postgres" ? join(" && ", [
+    join(" && ", compact([
       "mkdir -p /backup/${v.namespace}",
-      "PGPASSWORD=\"$DB_PASSWORD\" pg_dumpall -h ${v.db_host} -p ${v.db_port} -U \"$DB_USER\" | gzip > /backup/${v.namespace}/${k}-$(date +%Y%m%d-%H%M%S).sql.gz",
+      v.db_type == "postgres"
+      ? "PGPASSWORD=\"$DB_PASSWORD\" pg_dumpall -h ${v.db_host} -p ${v.db_port} -U \"$DB_USER\" | gzip > /backup/${v.namespace}/${k}-$(date +%Y%m%d-%H%M%S).sql.gz"
+      : "mysqldump -h ${v.db_host} -P ${v.db_port} -u \"$DB_USER\" -p\"$DB_PASSWORD\" --all-databases | gzip > /backup/${v.namespace}/${k}-$(date +%Y%m%d-%H%M%S).sql.gz",
       "find /backup/${v.namespace} -name '${k}-*.sql.gz' -mtime +${var.retention_days} -delete",
-      ]) : join(" && ", [
-      "mkdir -p /backup/${v.namespace}",
-      "mysqldump -h ${v.db_host} -P ${v.db_port} -u \"$DB_USER\" -p\"$DB_PASSWORD\" --all-databases | gzip > /backup/${v.namespace}/${k}-$(date +%Y%m%d-%H%M%S).sql.gz",
-      "find /backup/${v.namespace} -name '${k}-*.sql.gz' -mtime +${var.retention_days} -delete",
-    ])
+      v.push_url != "" ? "curl -fsS -m 10 --retry 3 \"$PUSH_URL\" > /dev/null" : "",
+    ]))
   }
 }
 
@@ -73,6 +72,14 @@ resource "kubernetes_cron_job_v1" "backup" {
                     name = each.value.secret_name
                     key  = each.value.secret_password_key
                   }
+                }
+              }
+
+              dynamic "env" {
+                for_each = each.value.push_url != "" ? [1] : []
+                content {
+                  name  = "PUSH_URL"
+                  value = each.value.push_url
                 }
               }
 

--- a/tf/db_backup/variables.tf
+++ b/tf/db_backup/variables.tf
@@ -10,6 +10,7 @@ variable "backups" {
     db_user             = optional(string, null)
     secret_username_key = optional(string, "username")
     secret_password_key = optional(string, "password")
+    push_url            = optional(string, "")
   }))
 
   validation {

--- a/tf/rsync_backup_lxc/main.tf
+++ b/tf/rsync_backup_lxc/main.tf
@@ -11,6 +11,7 @@ locals {
         destination      = job.destination
         flags            = job.flags
         exclude_patterns = job.exclude_patterns
+        push_url         = job.push_url
       }))
       service_b64 = base64encode(templatefile("${path.module}/templates/backup.service.tftpl", {
         name = job.name

--- a/tf/rsync_backup_lxc/templates/backup.sh.tftpl
+++ b/tf/rsync_backup_lxc/templates/backup.sh.tftpl
@@ -3,3 +3,6 @@ set -euo pipefail
 echo "$(date '+%Y-%m-%d %H:%M:%S') Starting ${name} backup..."
 rsync ${flags}%{ if length(exclude_patterns) > 0 } --exclude-from=/etc/rsync-excludes/${name}%{ endif } ${source} ${destination}
 echo "$(date '+%Y-%m-%d %H:%M:%S') ${name} backup complete."
+%{ if push_url != "" ~}
+curl -fsS -m 10 --retry 3 "${push_url}" > /dev/null
+%{ endif ~}

--- a/tf/rsync_backup_lxc/variables.tf
+++ b/tf/rsync_backup_lxc/variables.tf
@@ -104,5 +104,6 @@ variable "rsync_jobs" {
     flags            = string
     schedule         = string
     exclude_patterns = optional(list(string), [])
+    push_url         = optional(string, "")
   }))
 }

--- a/tf/uptimekuma_push_monitors/main.tf
+++ b/tf/uptimekuma_push_monitors/main.tf
@@ -1,0 +1,7 @@
+resource "uptimekuma_monitor_push" "monitor" {
+  for_each = var.monitors
+
+  name     = each.key
+  interval = each.value
+  active   = true
+}

--- a/tf/uptimekuma_push_monitors/outputs.tf
+++ b/tf/uptimekuma_push_monitors/outputs.tf
@@ -1,0 +1,7 @@
+output "push_urls" {
+  description = "Map of monitor name to full push URL."
+  value = {
+    for k, m in uptimekuma_monitor_push.monitor :
+    k => "${var.uptime_kuma_base_url}/api/push/${m.push_token}?status=up&msg=OK&ping="
+  }
+}

--- a/tf/uptimekuma_push_monitors/variables.tf
+++ b/tf/uptimekuma_push_monitors/variables.tf
@@ -1,0 +1,9 @@
+variable "monitors" {
+  description = "Map of push monitor definitions (name → interval in seconds)."
+  type        = map(number)
+}
+
+variable "uptime_kuma_base_url" {
+  description = "Base URL of Uptime Kuma instance (e.g. http://uptime-kuma.homelab.sigil.org)."
+  type        = string
+}


### PR DESCRIPTION
## Summary
- New `uptimekuma_push_monitors` module: creates push monitors via `breml/uptimekuma` provider, outputs `push_urls` map
- `rsync_backup_lxc`: optional `push_url` per job, curls on success
- `db_backup`: optional `push_url` per backup, curls on success via `PUSH_URL` env var

## Test plan
- [x] `terragrunt apply` on uptimekuma-monitors creates 11 push monitors in Uptime Kuma
- [x] `terragrunt apply` on db_backups wires push URLs into CronJob commands
- [x] `terragrunt apply` on rsync_backup wires push URLs into backup scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)