### PR TITLE
fix: use wget instead of curl for db_backup push notifications

### DIFF
--- a/tf/db_backup/main.tf
+++ b/tf/db_backup/main.tf
@@ -9,7 +9,7 @@ locals {
       ? "PGPASSWORD=\"$DB_PASSWORD\" pg_dumpall -h ${v.db_host} -p ${v.db_port} -U \"$DB_USER\" | gzip > /backup/${v.namespace}/${k}-$(date +%Y%m%d-%H%M%S).sql.gz"
       : "mysqldump -h ${v.db_host} -P ${v.db_port} -u \"$DB_USER\" -p\"$DB_PASSWORD\" --all-databases | gzip > /backup/${v.namespace}/${k}-$(date +%Y%m%d-%H%M%S).sql.gz",
       "find /backup/${v.namespace} -name '${k}-*.sql.gz' -mtime +${var.retention_days} -delete",
-      v.push_url != "" ? "curl -fsS -m 10 --retry 3 \"$PUSH_URL\" > /dev/null" : "",
+      v.push_url != "" ? "wget -q -T 10 -t 3 -O /dev/null \"$PUSH_URL\"" : "",
     ]))
   }
 }


### PR DESCRIPTION
## Summary
- Alpine-based postgres/mariadb images don't include curl
- Switch to `wget` which is available by default

## Test plan
- [ ] Trigger a manual db backup job, verify push received in Uptime Kuma

🤖 Generated with [Claude Code](https://claude.com/claude-code)