### PR TITLE
fix: use wget instead of curl in rsync backup push notification

### DIFF
--- a/tf/rsync_backup_lxc/templates/backup.sh.tftpl
+++ b/tf/rsync_backup_lxc/templates/backup.sh.tftpl
@@ -4,5 +4,5 @@ echo "$(date '+%Y-%m-%d %H:%M:%S') Starting ${name} backup..."
 rsync ${flags}%{ if length(exclude_patterns) > 0 } --exclude-from=/etc/rsync-excludes/${name}%{ endif } ${source} ${destination}
 echo "$(date '+%Y-%m-%d %H:%M:%S') ${name} backup complete."
 %{ if push_url != "" ~}
-curl -fsS -m 10 --retry 3 "${push_url}" > /dev/null
+wget -q -T 10 -t 3 -O /dev/null "${push_url}"
 %{ endif ~}


### PR DESCRIPTION
## Summary
- Debian minimal LXC template doesn't include curl
- Switch to `wget` which is available by default

## Test plan
- [ ] Taint + re-apply rsync_backup, verify backup scripts use wget
- [ ] Trigger a manual backup run, verify push received in Uptime Kuma

🤖 Generated with [Claude Code](https://claude.com/claude-code)