### PR TITLE
fix: install wget for mariadb backup push notifications

### DIFF
--- a/tf/db_backup/main.tf
+++ b/tf/db_backup/main.tf
@@ -9,7 +9,8 @@ locals {
       ? "PGPASSWORD=\"$DB_PASSWORD\" pg_dumpall -h ${v.db_host} -p ${v.db_port} -U \"$DB_USER\" | gzip > /backup/${v.namespace}/${k}-$(date +%Y%m%d-%H%M%S).sql.gz"
       : "mysqldump -h ${v.db_host} -P ${v.db_port} -u \"$DB_USER\" -p\"$DB_PASSWORD\" --all-databases | gzip > /backup/${v.namespace}/${k}-$(date +%Y%m%d-%H%M%S).sql.gz",
       "find /backup/${v.namespace} -name '${k}-*.sql.gz' -mtime +${var.retention_days} -delete",
-      v.push_url != "" ? "wget -q -T 10 -t 3 -O /dev/null \"$PUSH_URL\"" : "",
+      v.push_url != "" && v.db_type == "mariadb" ? "apt-get update -qq > /dev/null 2>&1 && apt-get install -y -qq wget > /dev/null 2>&1 && wget -q -T 10 -t 3 -O /dev/null \"$PUSH_URL\"" : "",
+      v.push_url != "" && v.db_type != "mariadb" ? "wget -q -T 10 -t 3 -O /dev/null \"$PUSH_URL\"" : "",
     ]))
   }
 }


### PR DESCRIPTION
## Summary
- MariaDB backup CronJob push notification fails because `mariadb:10.11` (Ubuntu-based) lacks `wget`
- Adds inline `apt-get install wget` for mariadb db_type when push_url is set
- Postgres (Alpine) already has busybox wget, so no change needed there

## Test plan
- [ ] Apply db_backups with push_url set for mariadb
- [ ] Trigger manual job run, verify push received in Uptime Kuma

🤖 Generated with [Claude Code](https://claude.com/claude-code)