### PR TITLE
feat: add optional static routes to rsync_backup_lxc

### DIFF
--- a/tf/rsync_backup_lxc/main.tf
+++ b/tf/rsync_backup_lxc/main.tf
@@ -111,6 +111,7 @@ resource "null_resource" "provision" {
     content = templatefile("${path.module}/templates/setup.sh.tftpl", {
       timezone               = var.timezone
       nfs_mounts             = var.nfs_mounts
+      static_routes          = var.static_routes
       backup_configs         = local.backup_configs
       backup_ssh_private_key = tls_private_key.backup_ssh.private_key_openssh
     })

--- a/tf/rsync_backup_lxc/templates/setup.sh.tftpl
+++ b/tf/rsync_backup_lxc/templates/setup.sh.tftpl
@@ -19,6 +19,16 @@ fi
 systemctl daemon-reload
 mount -a
 
+# Configure static routes
+%{ for route in static_routes ~}
+if ! ip route show ${route.destination} | grep -q 'via ${route.gateway}'; then
+  ip route add ${route.destination} via ${route.gateway}
+fi
+if ! grep -q '${route.destination} via ${route.gateway}' /etc/network/interfaces; then
+  echo "  up ip route add ${route.destination} via ${route.gateway}" >> /etc/network/interfaces
+fi
+%{ endfor ~}
+
 # Setup SSH keypair for backup destinations
 mkdir -p /root/.ssh
 chmod 700 /root/.ssh

--- a/tf/rsync_backup_lxc/variables.tf
+++ b/tf/rsync_backup_lxc/variables.tf
@@ -95,6 +95,15 @@ variable "nfs_mounts" {
   }))
 }
 
+variable "static_routes" {
+  description = "Static routes to add inside the container."
+  type = list(object({
+    destination = string
+    gateway     = string
+  }))
+  default = []
+}
+
 variable "rsync_jobs" {
   description = "Rsync backup job definitions."
   type = list(object({


### PR DESCRIPTION
## Summary
- Adds `static_routes` variable (list of `{destination, gateway}`) to the rsync_backup_lxc module
- Routes are applied immediately via `ip route add` and persisted in `/etc/network/interfaces`
- Fixes asymmetric routing issue where rsync to remote subnets (e.g. Tailnet peers) breaks when traffic goes through the firewall but responses bypass it on the same L2 segment

## Test plan
- [ ] Apply rsync_backup with `static_routes` set
- [ ] Taint null_resource.provision + re-apply to re-provision
- [ ] Verify `ip route show` on LXC includes the static route
- [ ] Verify route survives container reboot
- [ ] Run rsync job to remote destination, confirm no broken pipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)