### PR TITLE
feat: add docker_vm module

### DIFF
--- a/tf/docker_vm/main.tf
+++ b/tf/docker_vm/main.tf
@@ -16,7 +16,9 @@ resource "proxmox_vm_qemu" "vm" {
 
   clone = var.template
 
-  cores   = var.cores
+  cpu {
+    cores = var.cores
+  }
   memory  = var.memory
   start_at_node_boot = true
   scsihw  = "virtio-scsi-single"
@@ -48,7 +50,7 @@ resource "proxmox_vm_qemu" "vm" {
       bridge   = network.value.bridge
       firewall = true
       model    = "virtio"
-      tag      = network.value.tag > 0 ? network.value.tag : -1
+      tag      = network.value.tag > 0 ? network.value.tag : null
     }
   }
 

--- a/tf/docker_vm/main.tf
+++ b/tf/docker_vm/main.tf
@@ -18,7 +18,7 @@ resource "proxmox_vm_qemu" "vm" {
 
   cores   = var.cores
   memory  = var.memory
-  onboot  = true
+  start_at_node_boot = true
   scsihw  = "virtio-scsi-single"
   boot    = "order=scsi0"
   agent   = 1

--- a/tf/docker_vm/main.tf
+++ b/tf/docker_vm/main.tf
@@ -1,0 +1,131 @@
+locals {
+  # First NIC IP (without CIDR) used for SSH connection
+  primary_ip = split("/", var.networks[0].ip)[0]
+  subnet_bits = split("/", var.networks[0].ip)[1]
+
+  # Build ipconfig0..ipconfig3 from networks list
+  ipconfigs = {
+    for i, net in var.networks : "ipconfig${i}" =>
+      net.gateway != "" ? "ip=${net.ip},gw=${net.gateway}" : "ip=${net.ip}"
+  }
+}
+
+resource "proxmox_vm_qemu" "vm" {
+  target_node = var.proxmox_node
+  name        = var.hostname
+
+  clone = var.template
+
+  cores   = var.cores
+  memory  = var.memory
+  onboot  = true
+  scsihw  = "virtio-scsi-single"
+  boot    = "order=scsi0"
+  agent   = 1
+
+  disks {
+    scsi {
+      scsi0 {
+        disk {
+          storage = var.storage_id
+          size    = var.disk_size
+        }
+      }
+    }
+    ide {
+      ide1 {
+        cloudinit {
+          storage = var.cloudinit_storage_id
+        }
+      }
+    }
+  }
+
+  dynamic "network" {
+    for_each = { for i, net in var.networks : i => net }
+    content {
+      id       = network.key
+      bridge   = network.value.bridge
+      firewall = true
+      model    = "virtio"
+      tag      = network.value.tag > 0 ? network.value.tag : -1
+    }
+  }
+
+  # cloud-init
+  os_type    = "cloud-init"
+  ciuser     = var.user
+  ipconfig0  = lookup(local.ipconfigs, "ipconfig0", null)
+  ipconfig1  = lookup(local.ipconfigs, "ipconfig1", null)
+  ipconfig2  = lookup(local.ipconfigs, "ipconfig2", null)
+  ipconfig3  = lookup(local.ipconfigs, "ipconfig3", null)
+  sshkeys    = file(var.authorized_keys_file)
+  nameserver = var.nameserver
+}
+
+resource "null_resource" "provision" {
+  depends_on = [proxmox_vm_qemu.vm]
+
+  triggers = {
+    vm_id            = proxmox_vm_qemu.vm.id
+    compose_sha      = sha256(var.docker_compose_content)
+    env_sha          = sha256(jsonencode(var.env_vars))
+    setup_sha = sha256(templatefile("${path.module}/templates/setup.sh.tftpl", {
+      timezone        = var.timezone
+      nfs_mounts      = var.nfs_mounts
+      directories     = var.directories
+      sysctl_settings = var.sysctl_settings
+    }))
+  }
+
+  connection {
+    type = "ssh"
+    user = var.user
+    host = local.primary_ip
+  }
+
+  # 1. Push and run setup script
+  provisioner "file" {
+    destination = "/tmp/setup.sh"
+    content = templatefile("${path.module}/templates/setup.sh.tftpl", {
+      timezone        = var.timezone
+      nfs_mounts      = var.nfs_mounts
+      directories     = var.directories
+      sysctl_settings = var.sysctl_settings
+    })
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/setup.sh",
+      "sudo /tmp/setup.sh",
+      "rm /tmp/setup.sh",
+    ]
+  }
+
+  # 2. Push docker-compose.yml
+  provisioner "file" {
+    destination = "/tmp/docker-compose.yml"
+    content     = var.docker_compose_content
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/docker-compose.yml /opt/docker/docker-compose.yml",
+    ]
+  }
+
+  # 3. Push .env (even if empty, to clear stale vars)
+  provisioner "file" {
+    destination = "/tmp/docker.env"
+    content     = join("\n", [for k, v in var.env_vars : "${k}=${v}"])
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/docker.env /opt/docker/.env",
+      "sudo chmod 600 /opt/docker/.env",
+      "cd /opt/docker && sudo docker compose up -d --remove-orphans",
+    ]
+  }
+}

--- a/tf/docker_vm/outputs.tf
+++ b/tf/docker_vm/outputs.tf
@@ -1,0 +1,4 @@
+output "vm_ip" {
+  description = "Primary IP address of the VM (first NIC, without CIDR)."
+  value       = local.primary_ip
+}

--- a/tf/docker_vm/templates/setup.sh.tftpl
+++ b/tf/docker_vm/templates/setup.sh.tftpl
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+# Timezone
+ln -sf /usr/share/zoneinfo/${timezone} /etc/localtime
+echo "${timezone}" > /etc/timezone
+
+# Sysctl
+%{ for key, val in sysctl_settings ~}
+echo "${key}=${val}" > /etc/sysctl.d/99-${replace(key, ".", "-")}.conf
+%{ endfor ~}
+%{ if length(sysctl_settings) > 0 ~}
+sysctl --system
+%{ endif ~}
+
+# Install Docker (idempotent)
+if ! command -v docker &>/dev/null; then
+  curl -fsSL https://get.docker.com | sh
+fi
+
+# NFS client
+if ! dpkg -s nfs-common &>/dev/null 2>&1; then
+  apt-get update
+  apt-get install -y nfs-common
+fi
+
+# NFS mounts
+%{ for mount in nfs_mounts ~}
+mkdir -p ${mount.mount_point}
+if ! grep -q '${mount.server}:${mount.path} ${mount.mount_point}' /etc/fstab; then
+  echo "${mount.server}:${mount.path} ${mount.mount_point} nfs defaults,_netdev 0 0" >> /etc/fstab
+fi
+%{ endfor ~}
+%{ if length(nfs_mounts) > 0 ~}
+systemctl daemon-reload
+mount -a
+%{ endif ~}
+
+# Extra directories (after NFS mounts)
+%{ for dir in directories ~}
+mkdir -p ${dir}
+%{ endfor ~}
+
+# Docker workdir
+mkdir -p /opt/docker
+
+echo "docker_vm setup complete."

--- a/tf/docker_vm/variables.tf
+++ b/tf/docker_vm/variables.tf
@@ -1,0 +1,109 @@
+variable "proxmox_node" {
+  description = "Target Proxmox node for the VM."
+  type        = string
+}
+
+variable "hostname" {
+  description = "VM hostname."
+  type        = string
+}
+
+variable "template" {
+  description = "Cloud-init template name to clone."
+  type        = string
+}
+
+variable "storage_id" {
+  description = "Storage ID for the VM disk."
+  type        = string
+  default     = "local-lvm"
+}
+
+variable "cloudinit_storage_id" {
+  description = "Storage ID for the cloud-init drive."
+  type        = string
+}
+
+variable "disk_size" {
+  description = "OS disk size (e.g. 32G)."
+  type        = string
+  default     = "32G"
+}
+
+variable "cores" {
+  description = "Number of vCPUs."
+  type        = number
+  default     = 2
+}
+
+variable "memory" {
+  description = "RAM in MB."
+  type        = number
+  default     = 2048
+}
+
+variable "user" {
+  description = "Cloud-init user."
+  type        = string
+  default     = "ubuntu"
+}
+
+variable "networks" {
+  description = "Network interfaces: bridge, tag (0 = untagged), ip (CIDR), gateway (optional)."
+  type = list(object({
+    bridge  = string
+    tag     = optional(number, 0)
+    ip      = string
+    gateway = optional(string, "")
+  }))
+}
+
+variable "nameserver" {
+  description = "DNS server IP."
+  type        = string
+}
+
+variable "authorized_keys_file" {
+  description = "Path to file containing public SSH keys."
+  type        = string
+}
+
+variable "timezone" {
+  description = "Timezone for the VM (e.g. America/Denver)."
+  type        = string
+  default     = "UTC"
+}
+
+variable "nfs_mounts" {
+  description = "NFS shares to mount inside the VM."
+  type = list(object({
+    server      = string
+    path        = string
+    mount_point = string
+  }))
+  default = []
+}
+
+variable "directories" {
+  description = "Paths to mkdir -p after NFS mounts are ready."
+  type        = list(string)
+  default     = []
+}
+
+variable "sysctl_settings" {
+  description = "Custom sysctl key-value pairs."
+  type        = map(string)
+  default     = {}
+}
+
+variable "docker_compose_content" {
+  description = "Full docker-compose.yml content to deploy."
+  type        = string
+}
+
+variable "env_vars" {
+  description = "Environment variables written to /opt/docker/.env."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- Generic reusable Proxmox VM module for Docker Compose workloads via cloud-init + SSH provisioning
- Handles multi-NIC with VLAN tags, NFS mounts, sysctl tuning, and arbitrary env vars
- First consumer: Roon Server + sxm-streamer VM

## Test plan
- [x] `terragrunt plan` passes against `mesa/cluster/roon/` in infra repo
- [x] `terragrunt apply` — VM created, Docker running, NFS mounted, compose up

🤖 Generated with [Claude Code](https://claude.com/claude-code)