### PR TITLE
feat: add provisioned_lxc module

### DIFF
--- a/tf/provisioned_lxc/main.tf
+++ b/tf/provisioned_lxc/main.tf
@@ -1,0 +1,97 @@
+locals {
+  container_ip = split("/", var.ip_address)[0]
+}
+
+resource "random_password" "root" {
+  length  = 16
+  special = false
+}
+
+resource "proxmox_lxc" "container" {
+  target_node  = var.proxmox_node
+  hostname     = var.hostname
+  ostemplate   = var.ostemplate
+  password     = random_password.root.result
+  unprivileged = false
+  start        = true
+  onboot       = true
+
+  cores  = var.cores
+  memory = var.memory
+
+  rootfs {
+    storage = var.storage_id
+    size    = var.disk_size
+  }
+
+  network {
+    name   = "eth0"
+    bridge = var.network_bridge
+    ip     = var.ip_address
+    gw     = var.gateway
+  }
+
+  nameserver      = var.nameserver
+  ssh_public_keys = file(var.authorized_keys_file)
+}
+
+resource "null_resource" "nfs_feature_flag" {
+  count      = length(var.nfs_mounts) > 0 ? 1 : 0
+  depends_on = [proxmox_lxc.container]
+
+  triggers = {
+    lxc_id = proxmox_lxc.container.id
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      TICKET=$(curl -sk -d "username=${var.proxmox_user}" --data-urlencode "password=${var.proxmox_password}" \
+        "${var.proxmox_api_url}/access/ticket")
+      TOKEN=$(echo "$TICKET" | jq -r '.data.ticket')
+      CSRF=$(echo "$TICKET" | jq -r '.data.CSRFPreventionToken')
+      curl -sk -X PUT \
+        -H "Cookie: PVEAuthCookie=$TOKEN" \
+        -H "CSRFPreventionToken: $CSRF" \
+        -d "features=mount%3Dnfs" \
+        "${var.proxmox_api_url}/nodes/${var.proxmox_node}/lxc/${proxmox_lxc.container.vmid}/config"
+      curl -sk -X POST \
+        -H "Cookie: PVEAuthCookie=$TOKEN" \
+        -H "CSRFPreventionToken: $CSRF" \
+        "${var.proxmox_api_url}/nodes/${var.proxmox_node}/lxc/${proxmox_lxc.container.vmid}/status/reboot"
+      sleep 10
+    EOT
+  }
+}
+
+resource "null_resource" "provision" {
+  depends_on = [proxmox_lxc.container, null_resource.nfs_feature_flag]
+
+  triggers = {
+    lxc_id    = proxmox_lxc.container.id
+    setup_sha = sha256(var.setup_script)
+  }
+
+  connection {
+    type  = "ssh"
+    user  = "root"
+    host  = local.container_ip
+    agent = true
+  }
+
+  provisioner "file" {
+    destination = "/tmp/setup.sh"
+    content = templatefile("${path.module}/templates/setup.sh.tftpl", {
+      timezone     = var.timezone
+      nfs_mounts   = var.nfs_mounts
+      setup_script = var.setup_script
+    })
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/setup.sh",
+      "/tmp/setup.sh",
+      "rm /tmp/setup.sh",
+    ]
+  }
+}

--- a/tf/provisioned_lxc/outputs.tf
+++ b/tf/provisioned_lxc/outputs.tf
@@ -1,0 +1,4 @@
+output "container_ip" {
+  description = "IP address of the LXC container."
+  value       = local.container_ip
+}

--- a/tf/provisioned_lxc/templates/setup.sh.tftpl
+++ b/tf/provisioned_lxc/templates/setup.sh.tftpl
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# Timezone
+ln -sf /usr/share/zoneinfo/${timezone} /etc/localtime
+echo "${timezone}" > /etc/timezone
+
+%{ if length(nfs_mounts) > 0 ~}
+# NFS
+apt-get update
+apt-get install -y nfs-common
+
+%{ for mount in nfs_mounts ~}
+mkdir -p ${mount.mount_point}
+if ! grep -q '${mount.server}:${mount.path} ${mount.mount_point}' /etc/fstab; then
+  echo "${mount.server}:${mount.path} ${mount.mount_point} nfs defaults,_netdev 0 0" >> /etc/fstab
+fi
+%{ endfor ~}
+systemctl daemon-reload
+mount -a
+%{ endif ~}
+
+%{ if setup_script != "" ~}
+# Custom setup
+${setup_script}
+%{ endif ~}
+
+echo "Provisioning complete."

--- a/tf/provisioned_lxc/templates/setup.sh.tftpl
+++ b/tf/provisioned_lxc/templates/setup.sh.tftpl
@@ -20,6 +20,11 @@ systemctl daemon-reload
 mount -a
 %{ endif ~}
 
+# systemd-logind fails in LXC (status 226/NAMESPACE) and causes ~20s SSH delays
+# via pam_systemd. Mask it and disable the PAM module.
+systemctl mask systemd-logind
+sed -i 's/^session.*pam_systemd\.so/# &/' /etc/pam.d/common-session
+
 %{ if setup_script != "" ~}
 # Custom setup
 ${setup_script}

--- a/tf/provisioned_lxc/variables.tf
+++ b/tf/provisioned_lxc/variables.tf
@@ -1,0 +1,103 @@
+variable "proxmox_node" {
+  description = "Target Proxmox node for the LXC container."
+  type        = string
+}
+
+variable "proxmox_api_url" {
+  description = "Proxmox API URL (e.g. https://192.168.1.15:8006/api2/json)."
+  type        = string
+}
+
+variable "proxmox_user" {
+  description = "Proxmox user for API auth (password auth required for LXC feature flags)."
+  type        = string
+  default     = "root@pam"
+}
+
+variable "proxmox_password" {
+  description = "Proxmox password for API auth."
+  type        = string
+  sensitive   = true
+}
+
+variable "hostname" {
+  description = "Hostname for the LXC container."
+  type        = string
+}
+
+variable "ostemplate" {
+  description = "LXC template path (e.g. local:vztmpl/debian-12-standard_12.7-1_amd64.tar.zst)."
+  type        = string
+}
+
+variable "storage_id" {
+  description = "Storage ID for the container rootfs."
+  type        = string
+  default     = "local-lvm"
+}
+
+variable "disk_size" {
+  description = "Rootfs disk size."
+  type        = string
+  default     = "4G"
+}
+
+variable "cores" {
+  description = "Number of CPU cores."
+  type        = number
+  default     = 1
+}
+
+variable "memory" {
+  description = "Memory in MB."
+  type        = number
+  default     = 512
+}
+
+variable "ip_address" {
+  description = "Static IP in CIDR notation (e.g. 172.21.1.50/24)."
+  type        = string
+}
+
+variable "gateway" {
+  description = "Network gateway IP."
+  type        = string
+}
+
+variable "nameserver" {
+  description = "DNS server IP."
+  type        = string
+}
+
+variable "network_bridge" {
+  description = "Proxmox network bridge."
+  type        = string
+  default     = "vmbr0"
+}
+
+variable "authorized_keys_file" {
+  description = "Path to file containing public SSH keys for root access."
+  type        = string
+}
+
+variable "timezone" {
+  description = "Timezone for the container (e.g. America/Denver)."
+  type        = string
+  default     = "UTC"
+}
+
+variable "nfs_mounts" {
+  description = "NFS shares to mount inside the container."
+  type = list(object({
+    server      = string
+    path        = string
+    mount_point = string
+  }))
+  default = []
+}
+
+variable "setup_script" {
+  description = "Additional shell script content to run after base provisioning (NFS, timezone)."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- Generic reusable Proxmox LXC module extracted from rsync_backup_lxc pattern
- Handles NFS feature flag, NFS mounts, timezone, and arbitrary setup_script hook
- First consumer: music-tools LXC (beets + qobuz-dl)

## Test plan
- [x] `terragrunt plan` passes against `mesa/cluster/music-tools/` in infra repo
- [x] `terragrunt apply` — LXC created, NFS mounted, beets/qobuz-dl installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)