### PR TITLE
feat: add generic helm_release module

### DIFF
--- a/tf/helm_release/main.tf
+++ b/tf/helm_release/main.tf
@@ -1,0 +1,47 @@
+resource "dnsimple_zone_record" "dns_record" {
+  count = var.dnsimple_domain == "" ? 0 : 1
+
+  zone_name = "${var.dnsimple_domain}"
+  name      = "${var.dnsimple_record_name}"
+  value     = "${var.dnsimple_record_target}"
+  type      = "${var.dnsimple_record_type}"
+  ttl       = "${var.dnsimple_record_ttl}"
+}
+
+resource "helm_release" "helm_chart" {
+  name             = var.release_name
+  repository       = var.repository
+  chart            = var.chart_name
+  version          = var.chart_version
+  namespace        = var.namespace
+  create_namespace = true
+
+  set = concat(
+    [for idx, val in var.nfs_volumes : {
+      name  = "persistence.${val.name}.enabled"
+      value = true
+    }],
+
+    [for idx, val in var.nfs_volumes : {
+      name  = "persistence.${val.name}.type"
+      value = "nfs"
+    }],
+
+    [for idx, val in var.nfs_volumes : {
+      name  = "persistence.${val.name}.mountPath"
+      value = "/media/${val.name}"
+    }],
+
+    [for idx, val in var.nfs_volumes : {
+      name  = "persistence.${val.name}.path"
+      value = "${val.path}"
+    }],
+
+    [for idx, val in var.nfs_volumes : {
+      name  = "persistence.${val.name}.server"
+      value = "${val.server}"
+    }]
+  )
+
+  values = var.values
+}

--- a/tf/helm_release/main.tf
+++ b/tf/helm_release/main.tf
@@ -15,6 +15,7 @@ resource "helm_release" "helm_chart" {
   version          = var.chart_version
   namespace        = var.namespace
   create_namespace = true
+  cleanup_on_fail  = true
 
   set = concat(
     [for idx, val in var.nfs_volumes : {

--- a/tf/helm_release/variables.tf
+++ b/tf/helm_release/variables.tf
@@ -1,0 +1,60 @@
+variable "repository" {
+  description = "Helm repository URL (HTTP/HTTPS or OCI)"
+}
+
+variable "chart_name" {
+  description = "Name of the Helm chart"
+}
+
+variable "chart_version" {
+  description = "Version of the Helm chart to use"
+}
+
+variable "namespace" {
+  description = "Namespace to create for this release"
+}
+
+variable "release_name" {
+  description = "Name for the Helm release"
+}
+
+variable "nfs_volumes" {
+  description = "NFS volumes to mount"
+  type = list(
+    object({
+      name   = string,
+      server = string,
+      path   = string,
+    })
+  )
+}
+
+variable "dnsimple_domain" {
+  description = "Base domain under which to create DNSimple records"
+  default = ""
+}
+
+variable "dnsimple_record_name" {
+  description = "Name of the DNSimple domain name"
+  default = ""
+}
+
+variable "dnsimple_record_target" {
+  description = "Target to point domain names to"
+  default = ""
+}
+
+variable "dnsimple_record_type" {
+  description = "Type of DNS record to create"
+  default = "CNAME"
+}
+
+variable "dnsimple_record_ttl" {
+  description = "TTL for DNS record"
+  default = 3600
+}
+
+variable "values" {
+  description = "Raw YAML values to pass to the chart"
+  type = list(string)
+}

--- a/tf/truechart/main.tf
+++ b/tf/truechart/main.tf
@@ -15,6 +15,7 @@ resource "helm_release" "helm_chart" {
   version          = var.chart_version
   namespace        = var.namespace
   create_namespace = true
+  cleanup_on_fail  = true
 
   set = concat(
     [for idx, val in var.nfs_volumes : {


### PR DESCRIPTION
## Summary

- Adds `tf/helm_release/` module as a generic counterpart to `tf/truechart/`
- Only difference: `repository` is a variable rather than hardcoded to the TrueCharts OCI registry
- Enables deploying any third-party Helm chart (HTTP/HTTPS or OCI repos) using the same pattern

## Test plan

- [x] Deploy karakeep via `mesa/services/karakeep` in the infra repo once this merges