### PR TITLE
feat: add force_update variable to truechart module

### DIFF
--- a/tf/truechart/main.tf
+++ b/tf/truechart/main.tf
@@ -16,6 +16,7 @@ resource "helm_release" "helm_chart" {
   namespace        = var.namespace
   create_namespace = true
   cleanup_on_fail  = true
+  force_update     = var.force_update
 
   set = concat(
     [for idx, val in var.nfs_volumes : {

--- a/tf/truechart/variables.tf
+++ b/tf/truechart/variables.tf
@@ -50,6 +50,12 @@ variable "dnsimple_record_ttl" {
   default = 3600
 }
 
+variable "force_update" {
+  description = "Force resource replacement via delete/recreate if Helm patch fails (e.g. strategic merge patch conflicts)"
+  type        = bool
+  default     = false
+}
+
 variable "values" {
   description = "Raw YAML values to pass to the chart"
   type = list(string)


### PR DESCRIPTION
Allows per-release opt-in to helm upgrade --force for charts that produce strategic merge patch conflicts on upgrade (e.g. port list ordering changes).